### PR TITLE
feat: resize prompt

### DIFF
--- a/playground/bun.lock
+++ b/playground/bun.lock
@@ -17,9 +17,12 @@
         "lodash-es": "^4.17.21",
         "monaco-editor": "^0.52.2",
         "sanitize-html": "^2.15.0",
+        "split-grid": "^1.0.11",
+        "split.js": "^1.6.5",
         "svelte-file-dropzone": "^2.0.9",
         "svelte-highlight": "^7.8.2",
         "svelte-monaco": "^0.4.0",
+        "svelte-splitpanes": "^8.0.9",
         "tailwindcss": "^4.1.4",
         "unplugin-icons": "^22.1.0",
         "zod": "^3.24.2",
@@ -287,6 +290,8 @@
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
+    "esm-env-robust": ["esm-env-robust@0.0.3", "", { "dependencies": { "esm-env": "^1.0.0" } }, "sha512-90Gnuw2DALOqlL1581VxP3GHPUNHX9U+fQ+8FNcTTFClhY5gEggAAnJ3q1b2Oq23knRsjv8YpNeMRPaMLUymOA=="],
+
     "esrap": ["esrap@1.4.6", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
@@ -425,6 +430,10 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "split-grid": ["split-grid@1.0.11", "", {}, "sha512-ELtFtxc3r5we5GZfe6Fi0BFFxIi2M6BY1YEntBscKRDD3zx4JVHqx2VnTRSQu1BixCYSTH3MTjKd4esI2R7EgQ=="],
+
+    "split.js": ["split.js@1.6.5", "", {}, "sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw=="],
+
     "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
@@ -438,6 +447,8 @@
     "svelte-highlight": ["svelte-highlight@7.8.3", "", { "dependencies": { "highlight.js": "11.11.1" } }, "sha512-i4CE/6yda1fCh0ovUVATk1S1feu1y3+CV+l1brgtMPPRO9VTGq+hPpUjVEJWQkE7hPAgwgVpHccoa5M2gpKxYQ=="],
 
     "svelte-monaco": ["svelte-monaco@0.4.0", "", { "dependencies": { "@monaco-editor/loader": "^1.4.0", "monaco-themes": "^0.4.4" }, "peerDependencies": { "monaco-editor": ">=0.40.0 < 1", "svelte": ">=4.0.0" } }, "sha512-eImYtqdtw0oXnzNmTSeeBYH1/73ECx9gEebaxIqfossd96hIvbZSllNfG092WI7WRDcSzbFrwUVYXTeWBR0WDQ=="],
+
+    "svelte-splitpanes": ["svelte-splitpanes@8.0.9", "", { "dependencies": { "esm-env-robust": "0.0.3" }, "peerDependencies": { "svelte": "^4.2.19 || ^5.1.0" } }, "sha512-L3oLXTC99M191FInTXJ/f/2i0welRql1QuVbPaU8iy6nvCR6X9VyjHCsCpLqKGWHwqkWo/AM9CQ1c0nzlb+MkA=="],
 
     "tailwindcss": ["tailwindcss@4.1.4", "", {}, "sha512-1ZIUqtPITFbv/DxRmDr5/agPqJwF69d24m9qmM1939TJehgY539CtzeZRjbLt5G6fSy/7YqqYsfvoTEw9xUI2A=="],
 

--- a/playground/bun.lock
+++ b/playground/bun.lock
@@ -18,11 +18,9 @@
         "monaco-editor": "^0.52.2",
         "sanitize-html": "^2.15.0",
         "split-grid": "^1.0.11",
-        "split.js": "^1.6.5",
         "svelte-file-dropzone": "^2.0.9",
         "svelte-highlight": "^7.8.2",
         "svelte-monaco": "^0.4.0",
-        "svelte-splitpanes": "^8.0.9",
         "tailwindcss": "^4.1.4",
         "unplugin-icons": "^22.1.0",
         "zod": "^3.24.2",
@@ -290,8 +288,6 @@
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
-    "esm-env-robust": ["esm-env-robust@0.0.3", "", { "dependencies": { "esm-env": "^1.0.0" } }, "sha512-90Gnuw2DALOqlL1581VxP3GHPUNHX9U+fQ+8FNcTTFClhY5gEggAAnJ3q1b2Oq23knRsjv8YpNeMRPaMLUymOA=="],
-
     "esrap": ["esrap@1.4.6", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
@@ -432,8 +428,6 @@
 
     "split-grid": ["split-grid@1.0.11", "", {}, "sha512-ELtFtxc3r5we5GZfe6Fi0BFFxIi2M6BY1YEntBscKRDD3zx4JVHqx2VnTRSQu1BixCYSTH3MTjKd4esI2R7EgQ=="],
 
-    "split.js": ["split.js@1.6.5", "", {}, "sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw=="],
-
     "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
@@ -447,8 +441,6 @@
     "svelte-highlight": ["svelte-highlight@7.8.3", "", { "dependencies": { "highlight.js": "11.11.1" } }, "sha512-i4CE/6yda1fCh0ovUVATk1S1feu1y3+CV+l1brgtMPPRO9VTGq+hPpUjVEJWQkE7hPAgwgVpHccoa5M2gpKxYQ=="],
 
     "svelte-monaco": ["svelte-monaco@0.4.0", "", { "dependencies": { "@monaco-editor/loader": "^1.4.0", "monaco-themes": "^0.4.4" }, "peerDependencies": { "monaco-editor": ">=0.40.0 < 1", "svelte": ">=4.0.0" } }, "sha512-eImYtqdtw0oXnzNmTSeeBYH1/73ECx9gEebaxIqfossd96hIvbZSllNfG092WI7WRDcSzbFrwUVYXTeWBR0WDQ=="],
-
-    "svelte-splitpanes": ["svelte-splitpanes@8.0.9", "", { "dependencies": { "esm-env-robust": "0.0.3" }, "peerDependencies": { "svelte": "^4.2.19 || ^5.1.0" } }, "sha512-L3oLXTC99M191FInTXJ/f/2i0welRql1QuVbPaU8iy6nvCR6X9VyjHCsCpLqKGWHwqkWo/AM9CQ1c0nzlb+MkA=="],
 
     "tailwindcss": ["tailwindcss@4.1.4", "", {}, "sha512-1ZIUqtPITFbv/DxRmDr5/agPqJwF69d24m9qmM1939TJehgY539CtzeZRjbLt5G6fSy/7YqqYsfvoTEw9xUI2A=="],
 

--- a/playground/package.json
+++ b/playground/package.json
@@ -45,6 +45,7 @@
     "lodash-es": "^4.17.21",
     "monaco-editor": "^0.52.2",
     "sanitize-html": "^2.15.0",
+    "split-grid": "^1.0.11",
     "svelte-file-dropzone": "^2.0.9",
     "svelte-highlight": "^7.8.2",
     "svelte-monaco": "^0.4.0",

--- a/playground/src/Playground.svelte
+++ b/playground/src/Playground.svelte
@@ -3,6 +3,7 @@
   import Chat from "./components/Chat.svelte";
   import { runCode } from "./lib/nushell";
   import type { Message } from "./lib/types";
+  import Split from "split-grid";
 
   let messages = $state<Message[]>([]);
   let proccessing = $state(false);
@@ -20,10 +21,27 @@
       proccessing = false;
     })();
   }
+  let gutter = $state<HTMLDivElement>();
+  $effect(() => {
+    if (!gutter) return;
+    Split({
+      rowGutters: [
+        {
+          track: 1,
+          element: gutter,
+        },
+      ],
+      minSize: 150,
+    });
+  });
 </script>
 
 <div class="playground">
   <Chat class="grow" {messages} />
+  <div
+    bind:this={gutter}
+    class="cursor-row-resize bg-white opacity-10 hover:opacity-30 active:opacity-50"
+  ></div>
   <Prompt {onSend} disable={proccessing} />
 </div>
 
@@ -31,6 +49,6 @@
   .playground {
     height: 100vh;
     display: grid;
-    grid-template-rows: 1fr auto;
+    grid-template-rows: 1fr 10px 150px;
   }
 </style>

--- a/playground/src/Playground.svelte
+++ b/playground/src/Playground.svelte
@@ -38,7 +38,7 @@
 
 <div class="playground">
   <Chat class="grow" {messages} />
-  <div bind:this={gutter} class="gutter"></div>
+  <div bind:this={gutter} class="h-2 cursor-row-resize bg-gray-600"></div>
   <Prompt {onSend} disable={proccessing} />
 </div>
 
@@ -48,10 +48,5 @@
     display: grid;
     /* row heights: chat (flex), gutter (auto), prompt (initial 150px) */
     grid-template-rows: 1fr auto 150px;
-  }
-  .gutter {
-    height: 8px;
-    cursor: row-resize;
-    background-color: #4b5563; /* Tailwind gray-600 */
   }
 </style>

--- a/playground/src/Playground.svelte
+++ b/playground/src/Playground.svelte
@@ -38,10 +38,7 @@
 
 <div class="playground">
   <Chat class="grow" {messages} />
-  <div
-    bind:this={gutter}
-    class="cursor-row-resize bg-white opacity-10 hover:opacity-30 active:opacity-50"
-  ></div>
+  <div bind:this={gutter} class="gutter"></div>
   <Prompt {onSend} disable={proccessing} />
 </div>
 
@@ -49,6 +46,12 @@
   .playground {
     height: 100vh;
     display: grid;
-    grid-template-rows: 1fr 10px 150px;
+    /* row heights: chat (flex), gutter (auto), prompt (initial 150px) */
+    grid-template-rows: 1fr auto 150px;
+  }
+  .gutter {
+    height: 8px;
+    cursor: row-resize;
+    background-color: #4b5563; /* Tailwind gray-600 */
   }
 </style>

--- a/playground/src/app.css
+++ b/playground/src/app.css
@@ -6,8 +6,11 @@
   root: ":root";
   logs: true;
 }
+
 body {
   font-family: "Roboto Mono Variable", monospace;
+  height: 100vh;
+  overflow: hidden;
 }
 
 label {

--- a/playground/src/components/Chat.svelte
+++ b/playground/src/components/Chat.svelte
@@ -3,7 +3,7 @@
   import MessageItem from "./MessageItem.svelte";
 
   interface Props {
-    class: string;
+    class?: string;
     messages: Message[];
   }
 

--- a/playground/src/components/Prompt.svelte
+++ b/playground/src/components/Prompt.svelte
@@ -69,7 +69,9 @@
 
 <div class="h-full flex flex-col gap-4">
   <FilesBar class="w-full" {onFileClick} />
-  <div class="flex flex-1 w-full gap-4 items-stretch bg-gray-800 p-4 rounded-lg overflow-hidden">
+  <div
+    class="flex flex-1 w-full gap-4 items-stretch bg-gray-800 p-4 rounded-lg overflow-hidden"
+  >
     <div class="flex-1 border border-gray-600 rounded-md overflow-hidden">
       <MonacoEditor
         bind:value={code}
@@ -89,7 +91,7 @@
     <button
       class="btn btn-success px-4 py-2 self-start flex items-center gap-2"
       disabled={!code}
-      on:click={sendCode}
+      onclick={sendCode}
     >
       <Run class="w-5 h-5" /> Run
     </button>

--- a/playground/src/components/Prompt.svelte
+++ b/playground/src/components/Prompt.svelte
@@ -67,10 +67,10 @@
   };
 </script>
 
-<div class="grid grid-rows-[auto_1fr] gap-2 mx-2">
+<div class="h-full flex flex-col gap-4">
   <FilesBar class="w-full" {onFileClick} />
-  <div class="grid grid-cols-[1fr_auto] w-full gap-2 my-2 items-center">
-    <div class="h-full max-h-[99%] border-r-2 border-2 border-gray-500">
+  <div class="flex flex-1 w-full gap-4 items-stretch bg-gray-800 p-4 rounded-lg overflow-hidden">
+    <div class="flex-1 border border-gray-600 rounded-md overflow-hidden">
       <MonacoEditor
         bind:value={code}
         on:ready={handleEditorReady}
@@ -78,15 +78,20 @@
           language: "shell",
           theme: "vs-dark",
           minimap: { enabled: false },
-          scrollbar: { vertical: "hidden", horizontal: "hidden" },
+          scrollbar: { vertical: "auto", horizontal: "auto" },
           automaticLayout: true,
+          lineNumbers: "off",
+          wordWrap: "on",
+          fontSize: 14,
         }}
       />
     </div>
     <button
-      class="btn bg-green-700 transition-colors duration-200 hover:bg-green-800"
+      class="btn btn-success px-4 py-2 self-start flex items-center gap-2"
       disabled={!code}
-      onclick={sendCode}>Run <Run /></button
+      on:click={sendCode}
     >
+      <Run class="w-5 h-5" /> Run
+    </button>
   </div>
 </div>

--- a/playground/src/components/Prompt.svelte
+++ b/playground/src/components/Prompt.svelte
@@ -53,6 +53,7 @@
 
   $effect(() => {
     editor?.updateOptions({ readOnly: disable ?? false });
+    editor?.layout();
   });
 </script>
 
@@ -71,7 +72,7 @@
       code = `${code.substring(0, offset)}/files/${file} ${code.substring(offset)}`;
     }}
   />
-  <div class="flex w-full gap-2 mx-2 h-15 items-center">
+  <div class="flex w-full gap-2 mx-2 a items-center">
     <div class="grow w-full h-full border-r-2 border-2 border-gray-500">
       <MonacoEditor
         bind:value={code}
@@ -92,3 +93,9 @@
     >
   </div>
 </div>
+
+<style>
+  .a {
+    height: calc(100% - 75px);
+  }
+</style>

--- a/playground/src/components/Prompt.svelte
+++ b/playground/src/components/Prompt.svelte
@@ -85,6 +85,7 @@
           lineNumbers: "off",
           wordWrap: "on",
           fontSize: 14,
+          padding: { top: 14 },
         }}
       />
     </div>

--- a/playground/src/components/Prompt.svelte
+++ b/playground/src/components/Prompt.svelte
@@ -72,7 +72,7 @@
       code = `${code.substring(0, offset)}/files/${file} ${code.substring(offset)}`;
     }}
   />
-  <div class="flex w-full gap-2 mx-2 a items-center">
+  <div class="flex w-full gap-2 mx-2 editor-container items-center">
     <div class="grow w-full h-full border-r-2 border-2 border-gray-500">
       <MonacoEditor
         bind:value={code}
@@ -95,7 +95,7 @@
 </div>
 
 <style>
-  .a {
+  .editor-container {
     height: calc(100% - 75px);
   }
 </style>

--- a/playground/src/components/Prompt.svelte
+++ b/playground/src/components/Prompt.svelte
@@ -54,25 +54,23 @@
   $effect(() => {
     editor?.updateOptions({ readOnly: disable ?? false });
   });
+  const onFileClick = (file) => {
+    if (!editor) return;
+    const position = editor.getPosition();
+    if (!code || !position) {
+      code = `cat /files/${file}`;
+      return;
+    }
+    const offset = editor.getModel()?.getOffsetAt(position);
+    if (offset === undefined) return;
+    code = `${code.substring(0, offset)}/files/${file} ${code.substring(offset)}`;
+  };
 </script>
 
-<div class="flex flex-wrap gap-2 m-2 items-center">
-  <FilesBar
-    class="w-full"
-    onFileClick={(file) => {
-      if (!editor) return;
-      const position = editor.getPosition();
-      if (!code || !position) {
-        code = `cat /files/${file}`;
-        return;
-      }
-      const offset = editor.getModel()?.getOffsetAt(position);
-      if (offset === undefined) return;
-      code = `${code.substring(0, offset)}/files/${file} ${code.substring(offset)}`;
-    }}
-  />
-  <div class="flex w-full gap-2 mx-2 editor-container items-center">
-    <div class="grow w-full h-full border-r-2 border-2 border-gray-500">
+<div class="grid grid-rows-[auto_1fr] gap-2 mx-2">
+  <FilesBar class="w-full" {onFileClick} />
+  <div class="grid grid-cols-[1fr_auto] w-full gap-2 my-2 items-center">
+    <div class="h-full max-h-[99%] border-r-2 border-2 border-gray-500">
       <MonacoEditor
         bind:value={code}
         on:ready={handleEditorReady}
@@ -92,9 +90,3 @@
     >
   </div>
 </div>
-
-<style>
-  .editor-container {
-    height: calc(100% - 75px);
-  }
-</style>

--- a/playground/src/components/Prompt.svelte
+++ b/playground/src/components/Prompt.svelte
@@ -53,7 +53,6 @@
 
   $effect(() => {
     editor?.updateOptions({ readOnly: disable ?? false });
-    editor?.layout();
   });
 </script>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a draggable horizontal resizable gutter between the Chat and Prompt sections, allowing users to adjust their height in the Playground.

- **Improvements**
  - Updated the editor container to use a dynamic height for better layout adaptability.
  - Introduced a new file click handler to streamline inserting file paths into the editor.
  - Reorganized the Prompt component layout using flexbox with improved styling and scrollbar options for enhanced usability.

- **Style**
  - Modified body styling to fill the entire viewport and prevent scrolling for a cleaner appearance.

- **Bug Fixes**
  - Made the class property optional in the Chat component, improving flexibility when using this component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->